### PR TITLE
Expose only userId - Reports DTO

### DIFF
--- a/src/reports/dtos/report.dto.ts
+++ b/src/reports/dtos/report.dto.ts
@@ -1,0 +1,31 @@
+import { Expose, Transform } from 'class-transformer';
+
+export class ReportDto {
+  @Expose()
+  id: number;
+
+  @Expose()
+  price: number;
+
+  @Expose()
+  year: number;
+
+  @Expose()
+  lng: number;
+
+  @Expose()
+  lat: number;
+
+  @Expose()
+  make: string;
+
+  @Expose()
+  model: string;
+
+  @Expose()
+  mileage: number;
+
+  @Transform(({ obj }) => obj.user.id) //take the report entity, grab its user and then the id
+  @Expose()
+  userId: number;
+}

--- a/src/reports/reports.controller.ts
+++ b/src/reports/reports.controller.ts
@@ -1,9 +1,11 @@
+import { ReportDto } from './dtos/report.dto';
 import { User } from './../users/user.entity';
 import { ReportsService } from './reports.service';
 import { CreateReportDto } from './dtos/create-report.dto';
 import { Body, Controller, Post, UseGuards } from '@nestjs/common';
 import { AuthGuard } from '../guards/auth.guard';
 import { CurrentUser } from '../users/decorators/current-user.decorator';
+import { Serialize } from 'src/interceptors/serialize.interceptor';
 
 @Controller('reports')
 export class ReportsController {
@@ -11,6 +13,7 @@ export class ReportsController {
 
   @Post()
   @UseGuards(AuthGuard)
+  @Serialize(ReportDto)
   createReport(@Body() body: CreateReportDto, @CurrentUser() user: User) {
     //pass the user to create so that we can associate the report to a user
     return this.reportsService.create(body, user);


### PR DESCRIPTION
Created Report DTO to transform user relation and only expose the user ID instead of the whole user record. Using DTO with Serializer in Reports Controller's create method.