### PR TITLE
Admin Guard, Report Approval & CurrentUser Middleware

### DIFF
--- a/src/guards/admin.guard.ts
+++ b/src/guards/admin.guard.ts
@@ -1,0 +1,11 @@
+import { CanActivate, ExecutionContext } from '@nestjs/common';
+
+export class AdminGuard implements CanActivate {
+  canActivate(context: ExecutionContext) {
+    const request = context.switchToHttp().getRequest(); //grab request
+
+    if (!request.currentUser) return false; //if no user, exit
+
+    return request.currentUser.admin; //return if admin is true or false
+  }
+}

--- a/src/reports/dtos/approved-report.dto.ts
+++ b/src/reports/dtos/approved-report.dto.ts
@@ -1,0 +1,6 @@
+import { IsBoolean } from 'class-validator';
+
+export class ApprovedReportDto {
+  @IsBoolean()
+  approved: boolean;
+}

--- a/src/reports/dtos/report.dto.ts
+++ b/src/reports/dtos/report.dto.ts
@@ -5,6 +5,9 @@ export class ReportDto {
   id: number;
 
   @Expose()
+  approved: boolean;
+
+  @Expose()
   price: number;
 
   @Expose()

--- a/src/reports/report.entity.ts
+++ b/src/reports/report.entity.ts
@@ -6,6 +6,9 @@ export class Report {
   @PrimaryGeneratedColumn()
   id: number;
 
+  @Column({ default: false })
+  approved: boolean;
+
   @Column()
   price: number;
 

--- a/src/reports/reports.controller.ts
+++ b/src/reports/reports.controller.ts
@@ -1,11 +1,20 @@
+import { AdminGuard } from '../guards/admin.guard';
+import { ApprovedReportDto } from './dtos/approved-report.dto';
 import { ReportDto } from './dtos/report.dto';
 import { User } from './../users/user.entity';
 import { ReportsService } from './reports.service';
 import { CreateReportDto } from './dtos/create-report.dto';
-import { Body, Controller, Post, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Param,
+  Patch,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
 import { AuthGuard } from '../guards/auth.guard';
 import { CurrentUser } from '../users/decorators/current-user.decorator';
-import { Serialize } from 'src/interceptors/serialize.interceptor';
+import { Serialize } from '../interceptors/serialize.interceptor';
 
 @Controller('reports')
 export class ReportsController {
@@ -17,5 +26,11 @@ export class ReportsController {
   createReport(@Body() body: CreateReportDto, @CurrentUser() user: User) {
     //pass the user to create so that we can associate the report to a user
     return this.reportsService.create(body, user);
+  }
+
+  @Patch('/:id')
+  @UseGuards(AdminGuard)
+  approveReport(@Param('id') id: string, @Body() body: ApprovedReportDto) {
+    return this.reportsService.changeApproval(id, body.approved);
   }
 }

--- a/src/reports/reports.service.ts
+++ b/src/reports/reports.service.ts
@@ -1,6 +1,6 @@
 import { User } from './../users/user.entity';
 import { CreateReportDto } from './dtos/create-report.dto';
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Report } from './report.entity';
@@ -15,6 +15,22 @@ export class ReportsService {
     //relate the user to the report
     report.user = user;
 
+    return this.repo.save(report);
+  }
+
+  async changeApproval(id: string, approved: boolean) {
+    //find report
+    const report = await this.repo.findOne(id);
+
+    //if not found, throw
+    if (!report) {
+      throw new NotFoundException('Report Not Found');
+    }
+
+    //assign the value of approved
+    report.approved = approved;
+
+    //return/save report
     return this.repo.save(report);
   }
 }

--- a/src/reports/requests.http
+++ b/src/reports/requests.http
@@ -11,3 +11,11 @@ content-type: application/json
 	"lat": 0,
 	"price": 50000
 }
+
+### Approve a report
+PATCH http://localhost:3000/reports/1
+content-type: application/json
+
+{
+	"approved": true
+}

--- a/src/users/middlewares/current-user.middleware.ts
+++ b/src/users/middlewares/current-user.middleware.ts
@@ -1,0 +1,28 @@
+import { UsersService } from './../users.service';
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { NextFunction, Request, Response } from 'express';
+
+//Make class injectable so that we can inject our user service
+@Injectable()
+export class CurrentUserMiddleware implements NestMiddleware {
+  //define cosntructor with user service
+  constructor(private usersService: UsersService) {}
+
+  //middlewares need the use method to access the incoming req
+  async use(req: Request, res: Response, next: NextFunction) {
+    //grab userId from the session
+    const { userId } = req.session || {};
+
+    //if there is a user
+    if (userId) {
+      //find that user
+      const user = await this.usersService.findOne(userId);
+      //@ts-ignore
+      //assign it to the currentUser on the req.
+      req.currentUser = user;
+    }
+
+    //exit this middleware
+    next();
+  }
+}

--- a/src/users/user.entity.ts
+++ b/src/users/user.entity.ts
@@ -20,6 +20,9 @@ export class User {
   @Column()
   password: string;
 
+  @Column({ default: true })
+  admin: boolean;
+
   //Decorator so that One User can have many Reports
   //This will NOT add a column to DB
   @OneToMany(() => Report, (report) => report.user)

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -1,7 +1,6 @@
-import { APP_INTERCEPTOR } from '@nestjs/core';
-import { CurrentUserInterceptor } from './interceptors/current-user.interceptor';
+import { CurrentUserMiddleware } from './middlewares/current-user.middleware';
 import { AuthService } from './auth.service';
-import { Module } from '@nestjs/common';
+import { MiddlewareConsumer, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
@@ -10,15 +9,12 @@ import { User } from './user.entity';
 @Module({
   imports: [TypeOrmModule.forFeature([User])],
   controllers: [UsersController],
-  providers: [
-    UsersService,
-    AuthService,
-    //config obj to set up
-    //a global interceptor
-    {
-      provide: APP_INTERCEPTOR,
-      useClass: CurrentUserInterceptor,
-    },
-  ],
+  providers: [UsersService, AuthService],
 })
-export class UsersModule {}
+export class UsersModule {
+  //configure the module for middlwares and etc.
+  configure(consumer: MiddlewareConsumer) {
+    //apply the middleware to all routes
+    consumer.apply(CurrentUserMiddleware).forRoutes('*');
+  }
+}


### PR DESCRIPTION
Created Admin Guard to only allow req if a user is an admin. Added admin column to the user entity. Added Patch endpoint to reports to change the approval of a report. Added approved column to report entity and DTO. Created an approved-report DTO to validate a change of report. Added a method in the report service to actually change the approval. Created a current user middleware to use instead of an interceptor. Added middleware to users module.