### PR TITLE
TypeOrm CLI & Environment Config for DBs

### DIFF
--- a/migrations/1647920352748-initial-schema.js
+++ b/migrations/1647920352748-initial-schema.js
@@ -1,0 +1,64 @@
+const { MigrationInterface, QueryRunner, Table } = require('typeorm');
+ 
+module.exports = class initialSchema1647920352748 {
+  name = 'initialSchema1647920352748';
+ 
+  async up(queryRunner) {
+    await queryRunner.createTable(
+      new Table({
+        name: 'user',
+        columns: [
+          {
+            name: 'id',
+            type: 'integer',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'increment',
+          },
+          {
+            name: 'email',
+            type: 'varchar',
+          },
+          {
+            name: 'password',
+            type: 'varchar',
+          },
+          {
+            name: 'admin',
+            type: 'boolean',
+            default: 'true',
+          },
+        ],
+      }),
+    );
+ 
+    await queryRunner.createTable(
+      new Table({
+        name: 'report',
+        columns: [
+          {
+            name: 'id',
+            type: 'integer',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'increment',
+          },
+          { name: 'approved', type: 'boolean', default: 'false' },
+          { name: 'price', type: 'float' },
+          { name: 'make', type: 'varchar' },
+          { name: 'model', type: 'varchar' },
+          { name: 'year', type: 'integer' },
+          { name: 'lng', type: 'float' },
+          { name: 'lat', type: 'float' },
+          { name: 'mileage', type: 'integer' },
+          { name: 'userId', type: 'integer' },
+        ],
+      }),
+    );
+  }
+ 
+  async down(queryRunner) {
+    await queryRunner.query(`DROP TABLE ""report""`);
+    await queryRunner.query(`DROP TABLE ""user""`);
+  }
+};

--- a/ormconfig.js
+++ b/ormconfig.js
@@ -1,0 +1,38 @@
+var dbConfig = {
+	synchronize: false,
+	//migrations will be js files
+	migrations: ['migrations/*.js'],
+	//tell cli to generate migrations on this folder
+	cli: {
+		migrationsDir: 'migrations'
+	}
+};
+
+//switch depending of environment
+switch(process.env.NODE_ENV) {
+	case 'development':
+		Object.assign(dbConfig, {
+			type: 'sqlite',
+			database: 'db.sqlite',
+			//js files work just fine on development, so we can look for them in
+			//the dist folder of the project
+			entities: ['**/*.entity.js'],
+		});
+		break;
+	case 'test':
+		Object.assign(dbConfig, {
+			type: 'sqlite',
+			database: 'test.sqlite',
+			//Testing with Jest on Nest require us to use TS files
+			//to run tests
+			entities: ['**/*.entity.ts'],
+			//cause migrations to run for each test
+			migrationsRun: true
+		});
+	case 'production':
+		break;
+	default:
+		throw new Error('Unknown Environment')
+}
+
+module.exports = dbConfig;

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test:watch": "cross-env NODE_ENV=test jest --watch --maxWorkers=1",
     "test:cov": "cross-env NODE_ENV=test jest --coverage",
     "test:debug": "cross-env NODE_ENV=test node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "cross-env NODE_ENV=test jest --config ./test/jest-e2e.json --maxWorkers=1"
+    "test:e2e": "cross-env NODE_ENV=test jest --config ./test/jest-e2e.json --maxWorkers=1",
+    "typeorm": "cross-env NODE_ENV=development node --require ts-node/register ./node_modules/typeorm/cli.js"
   },
   "dependencies": {
     "@nestjs/common": "^8.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     "noImplicitAny": false,
     "strictBindCallApply": false,
     "forceConsistentCasingInFileNames": false,
-    "noFallthroughCasesInSwitch": false
+    "noFallthroughCasesInSwitch": false,
+		"allowJs": true
   }
 }


### PR DESCRIPTION
Added necessary config so that migrations can be generated and run in all environments and so that typeorm can run different DBs depending on the environment we are in. This is for test and developmen so far.